### PR TITLE
Use predefined variables

### DIFF
--- a/flaskblog/config.py
+++ b/flaskblog/config.py
@@ -2,8 +2,8 @@ import os
 
 
 class Config:
-    SECRET_KEY = os.environ.get('SECRET_KEY')
-    SQLALCHEMY_DATABASE_URI = os.environ.get('SQLALCHEMY_DATABASE_URI')
+    SECRET_KEY = 'ITSaSECrEtKeYy'
+    SQLALCHEMY_DATABASE_URI = 'sqlite:///site.db'
     MAIL_SERVER = 'smtp.googlemail.com'
     MAIL_PORT = 587
     MAIL_USE_TLS = True


### PR DESCRIPTION
Using environment variables throws an error.
`
AttributeError: 'NoneType' object has no attribute 'drivername'
`